### PR TITLE
Read basic auth options from application config at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ control for security reasons.
 
 ### Store credentials in config files
 
-Instead of passing credentials into the plug directly, we can pass a tuple to the plug to tell
+Instead of passing credentials into the plug directly, we can pass a `use_config` option to the plug to tell
 it we want to use some variables we've stored in config files:
 
 ```elixir
   # inside router or controller file
-  plug BasicAuth, {:application_config, :admin_basic_auth}
+  plug BasicAuth, use_config: :admin_basic_auth
 ```
 
 And then we can setup some configuration using something like the following:

--- a/lib/basic_auth.ex
+++ b/lib/basic_auth.ex
@@ -1,4 +1,8 @@
 defmodule BasicAuth do
+  def init(options = {:application_config, _}) do
+    options
+  end
+
   def init(options) do
     #Better to fail at compile time if keys are incorrect
     [:password, :realm, :username] = Keyword.keys(options) |> Enum.sort
@@ -30,6 +34,11 @@ defmodule BasicAuth do
     Plug.Conn.put_resp_header(conn, "www-authenticate", "Basic realm=\"#{realm}\"")
     |> Plug.Conn.send_resp(401, "401 Unauthorized")
     |> Plug.Conn.halt
+  end
+
+
+  defp option_value({:application_config, application}, key) do
+    Application.get_env(application, key)
   end
 
   defp option_value(options, key) do

--- a/lib/basic_auth.ex
+++ b/lib/basic_auth.ex
@@ -4,11 +4,10 @@ defmodule BasicAuth do
   end
 
   def init(options) do
-    #Better to fail at compile time if keys are incorrect
+    # Better to fail at compile time if keys are incorrect
     [:password, :realm, :username] = Keyword.keys(options) |> Enum.sort
     options
   end
-
 
   def call(conn, options) do
     header_content = Plug.Conn.get_req_header(conn, "authorization")
@@ -35,7 +34,6 @@ defmodule BasicAuth do
     |> Plug.Conn.send_resp(401, "401 Unauthorized")
     |> Plug.Conn.halt
   end
-
 
   defp option_value({:application_config, application}, key) do
     Application.get_env(application, key)

--- a/lib/basic_auth.ex
+++ b/lib/basic_auth.ex
@@ -1,5 +1,5 @@
 defmodule BasicAuth do
-  def init(options = {:application_config, _}) do
+  def init([use_config: _] = options) do
     options
   end
 
@@ -35,8 +35,8 @@ defmodule BasicAuth do
     |> Plug.Conn.halt
   end
 
-  defp option_value({:application_config, application}, key) do
-    Application.get_env(application, key)
+  defp option_value([use_config: config_key], key) do
+    Application.get_env(config_key, key)
   end
 
   defp option_value(options, key) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule BasicAuth.Mixfile do
     [app: :basic_auth,
      description: "Basic Authentication Plug",
      package: package,
-     version: "0.0.2",
+     version: "1.0.0",
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
@@ -22,7 +22,7 @@ defmodule BasicAuth.Mixfile do
   end
 
   defp package do
-    [contributors: ["Mark Connell",],
+    [contributors: ["Mark Connell", "Paul Wilson"],
      licenses: ["MIT"],
      links: %{github: "https://github.com/cultivatehq/basic_auth"},
      files: ~w(lib LICENSE.md mix.exs README.md)]

--- a/test/basic_auth_test.exs
+++ b/test/basic_auth_test.exs
@@ -12,13 +12,9 @@ defmodule BasicAuthTest do
     defp index(conn, _opts), do: conn |> send_resp(200, "OK")
   end
 
-  defp call(conn) do
-    DemoPlug.call(conn, [])
-  end
-
   test "no credentials returns a 401" do
     conn = conn(:get, "/")
-    |> call
+    |> DemoPlug.call([])
 
     assert conn.status == 401
     assert Plug.Conn.get_resp_header(conn, "www-authenticate") == [ "Basic realm=\"Admin Area\""]
@@ -29,7 +25,7 @@ defmodule BasicAuthTest do
 
     conn = conn(:get, "/")
     |> put_req_header("authorization", header_content)
-    |> call
+    |> DemoPlug.call([])
 
     assert conn.status == 401
   end
@@ -39,7 +35,7 @@ defmodule BasicAuthTest do
 
     conn = conn(:get, "/")
     |> put_req_header("authorization", header_content)
-    |> call
+    |> DemoPlug.call([])
 
     assert conn.status == 401
   end
@@ -49,7 +45,7 @@ defmodule BasicAuthTest do
 
     conn = conn(:get, "/")
     |> put_req_header("authorization", header_content)
-    |> call
+    |> DemoPlug.call([])
 
     assert conn.status == 200
   end

--- a/test/basic_auth_test.exs
+++ b/test/basic_auth_test.exs
@@ -53,4 +53,48 @@ defmodule BasicAuthTest do
 
     assert conn.status == 200
   end
+
+  defmodule DemoPlugApplicationConfigured do
+    use Plug.Builder
+
+    plug BasicAuth, {:application_config, :myapp}
+
+    plug :index
+    defp index(conn, _opts), do: conn |> send_resp(200, "OK")
+  end
+
+  test "reading credentials from application config happens at runtime" do
+    {_realm, username, password} = setup_application_config
+
+    header_content = "Basic " <> Base.encode64("#{username}:#{password}")
+
+    conn = conn(:get, "/")
+    |> put_req_header("authorization", header_content)
+    |> DemoPlugApplicationConfigured.call([])
+
+    assert conn.status == 200
+  end
+
+  test "realm from application config is read at runtime" do
+    {realm, _, _} = setup_application_config
+
+    conn = conn(:get, "/")
+    |> DemoPlugApplicationConfigured.call([])
+
+    assert conn.status == 401
+    assert Plug.Conn.get_resp_header(conn, "www-authenticate") == [ "Basic realm=\"my realm\""]
+  end
+
+  defp setup_application_config do
+    appname = :myapp
+    username = "user"
+    password = "passw0rd"
+    realm = "my realm"
+
+    Application.put_env(appname, :realm, realm)
+    Application.put_env(appname, :username, username)
+    Application.put_env(appname, :password, password)
+
+    {realm, username, password}
+  end
 end

--- a/test/basic_auth_test.exs
+++ b/test/basic_auth_test.exs
@@ -53,7 +53,7 @@ defmodule BasicAuthTest do
   defmodule DemoPlugApplicationConfigured do
     use Plug.Builder
 
-    plug BasicAuth, {:application_config, :myapp}
+    plug BasicAuth, use_config: :myapp
 
     plug :index
     defp index(conn, _opts), do: conn |> send_resp(200, "OK")

--- a/test/basic_auth_test.exs
+++ b/test/basic_auth_test.exs
@@ -21,6 +21,7 @@ defmodule BasicAuthTest do
     |> call
 
     assert conn.status == 401
+    assert Plug.Conn.get_resp_header(conn, "www-authenticate") == [ "Basic realm=\"Admin Area\""]
   end
 
   test "invalid credentials returns a 401" do


### PR DESCRIPTION
This solves an issue I encountered while trying to deploy to Heroku, and following the Heroku pattern of using Heroku Config to set environment variables for secret configuration.

Because `plug` is a Macro, it is evaluated at compile time so however it is done, any configuration set from environment variables will depend on the compile-time environment, not the runtime environment. This enables the configuration to be read at runtime, so the following will actually work (on Heroku)

```
config :basic_auth, realm: "My Realm",
        username: System.get_env("BASIC_AUTH_USER"),
        password: System.get_env("BASIC_AUTH_PASSWORD")
```

What do you think, @mconnell? 