### PR TITLE
Remove assertion of HTML response in no-credential test

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ test "GET / without basic auth credentials prevents access" do
   conn = conn
     |> get("/admin/users")
 
-  assert html_response(conn, 401) =~ "401 Unauthorized"
+  assert response(conn, 401) =~ "401 Unauthorized"
 end
 ```


### PR DESCRIPTION
Thanks for this library, it was so easy to integrate!

Without this change, I was getting this test failure:
`** (RuntimeError) no content-type was set, expected a html response`