### PR TITLE
Support runtime credential configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ config :the_app, :basic_auth, [
 config :the_app, :basic_auth, [
   realm: "Admin Area",
   username: System.get_env("BASIC_AUTH_USER"),
-  password: System.get_env("BASIC_AUTH_PASSWORD")
+  password: {:system, "BASIC_AUTH_PASSWORD"}
 ]
 ```
 
 The example above for `config/prod.exs` makes use of system ENV vars. You could use String objects
 if your `config/prod.exs` is outside of version control, but for environments like Heroku, it's easier
-to use ENV vars for storing configuration.
+to use ENV vars for storing configuration. When a tuple like `{:system,
+"BASIC_AUTH_PASSWORD"}` is provided the value will be referenced from
+`System.get_env("BASIC_AUTH_PASSWORD")` at run time.
 
 ## Testing controllers with Basic Auth
 

--- a/lib/basic_auth.ex
+++ b/lib/basic_auth.ex
@@ -37,10 +37,14 @@ defmodule BasicAuth do
 
   defp option_value([use_config: {app, config_key}], option_key) do
     Application.fetch_env!(app, config_key)
-    |> Keyword.get(option_key) || raise ArgumentError, "value for option #{inspect option_key} is not set"
+    |> Keyword.get(option_key)
+    |> to_value || raise ArgumentError, "value for option #{inspect option_key} is not set"
   end
 
   defp option_value(options, key) do
-    options[key]
+    to_value(options[key])
   end
+
+  defp to_value({:system, env_var}), do: System.get_env(env_var)
+  defp to_value(value), do: value
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule BasicAuth.Mixfile do
     [app: :basic_auth,
      description: "Basic Authentication Plug",
      package: package,
-     version: "1.1.0-rc",
+     version: "1.2.0-rc",
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Allow the use of a `{:system, "ENV_VAR"}` tuple in config to allow for reading from the system env at run time, I think this should address #7 
