### PR TITLE
Allow custom auth logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ Add the package as a dependency in your Elixir project using something along the
 Add into the top of a controller, or into a router pipeline a plug declaration like:
 
 ```elixir
+  plug BasicAuth, callback: &User.find_by_username_and_password/2
+```
+
+  Where callback is your custom authentication function that takes a username and a 
+  password and returns a boolean.  This allows you to check the provided basic auth
+  credentials against a database.
+  
+
+Alternatively if you only want to allow a simple check against a static username and password
+you can provide a configuration like:
+
+
+```elixir
 plug BasicAuth, use_config: {:your_app, :your_key}
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # BasicAuth
 
 This is an Elixir Plug for adding basic authentication into an application.
+You can either provide a static application configuration or a custom
+authentication function.
 
 ## Breaking change
 
@@ -25,22 +27,8 @@ Add the package as a dependency in your Elixir project using something along the
 Add into the top of a controller, or into a router pipeline a plug declaration like:
 
 ```elixir
-  plug BasicAuth, callback: &User.find_by_username_and_password/2
-```
-
-  Where callback is your custom authentication function that takes a username and a 
-  password and returns a boolean.  This allows you to check the provided basic auth
-  credentials against a database.
-  
-
-Alternatively if you only want to allow a simple check against a static username and password
-you can provide a configuration like:
-
-
-```elixir
 plug BasicAuth, use_config: {:your_app, :your_key}
 ```
-
 
   Where :your_app and :your_key should refer to values in your application config.
 
@@ -64,6 +52,18 @@ plug BasicAuth, use_config: {:your_app, :your_key}
     realm:    {:system, "BASIC_AUTH_REALM"}
   ]
   ```
+
+Alternatively you can provide a custom function to the plug to authenticate the user any way
+you want, such as finding from a database.
+
+```elixir
+  plug BasicAuth, callback: &User.find_by_username_and_password/3
+```
+
+  Where :callback is your custom authentication function that takes a conn, username and a 
+  password and returns a conn.  Your function must return `Plug.Conn.halt(conn)` if authentication
+  fails, otherwise you can use `Plug.Conn.assign(conn, :current_user, ...)` to enhance
+  the conn with variables or session for your controller.
 
 Easy as that!
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # BasicAuth
 
 This is an Elixir Plug for adding basic authentication into an application.
-You can either provide a static application configuration or a custom
-authentication function.
+
+The plug can be configured to use:
+
+1) Static username and password in application configuration
+
+-OR-
+
+2) Your own custom authentication function
 
 ## Breaking change
 
@@ -54,7 +60,7 @@ plug BasicAuth, use_config: {:your_app, :your_key}
   ```
 
 Alternatively you can provide a custom function to the plug to authenticate the user any way
-you want, such as finding from a database.
+you want, such as finding the user from a database.
 
 ```elixir
   plug BasicAuth, callback: &User.find_by_username_and_password/3

--- a/lib/basic_auth.ex
+++ b/lib/basic_auth.ex
@@ -47,27 +47,47 @@ defmodule BasicAuth do
   def init(_) do
     raise ArgumentError, """
 
-    Usage of BasicAuth is:
+    Usage of BasicAuth using application config:
     plug BasicAuth, use_config: {:your_app, :your_key}
+    
+    -OR-
+    Using custom authentication function:
+    plug BasicAuth, callback: &MyCustom.function/3
 
-    Where :your_app and :your_key should refer to values in your application config. 
-
-    OR
-
-    plug BasicAuth, callback: &your_function/2
-
-    Where your_function takes a username and password and returns a boolean.  Your your_function
-    can check a database for example.
+    Where :callback takes a conn, username and password and returns a conn.  
     """
   end
 
   def call(conn, options) do
     header_content = Plug.Conn.get_req_header(conn, "authorization")
-    respond(valid_credentials?(header_content, options), conn, options)
+    respond(conn, header_content, options)
+  end
+  
+  defp respond(conn, ["Basic " <> encoded_string], options) do
+    [username, password] = Base.decode64!(encoded_string) |> String.split(":")
+    respond(conn, username, password, options)
   end
 
-  defp respond(true, conn, _), do: conn
-  defp respond(false, conn, options), do: send_unauthorized_response(conn, options)
+  defp respond(conn, _, options) do
+    send_unauthorized_response(conn, options)
+  end
+
+  defp respond(conn, username, password, %{callback: callback}) do
+    conn = callback.(conn, username, password)
+    if conn.halted do
+      send_unauthorized_response(conn, %{})
+    else
+      conn
+    end
+  end
+
+  defp respond(conn, username, password, %{username: config_usr, password: config_pwd, realm: realm}) do
+    if {username, password} == {to_value(config_usr), to_value(config_pwd)} do
+      conn
+    else
+      send_unauthorized_response(conn, %{realm: realm})
+    end
+  end
 
   defp config_option({app, config_key}, configuration, key) do
     Keyword.get(configuration, key) ||
@@ -76,15 +96,6 @@ defmodule BasicAuth do
       """
   end
 
-  defp valid_credentials?(["Basic " <> encoded_string], %{callback: callback}) do
-    [username, password] = Base.decode64!(encoded_string) |> String.split(":")
-    callback.(username, password)
-  end
-  defp valid_credentials?(["Basic " <> encoded_string], %{username: username, password: password}) do
-    Base.decode64!(encoded_string) == "#{to_value(username)}:#{to_value(password)}"
-  end
-  defp valid_credentials?(_,_), do: false
-
   defp send_unauthorized_response(conn, %{realm: realm}) do
     conn
     |> Plug.Conn.put_resp_header("www-authenticate", "Basic realm=\"#{to_value(realm)}\"")
@@ -92,7 +103,7 @@ defmodule BasicAuth do
     |> Plug.Conn.halt
   end
 
-  defp send_unauthorized_response(conn, %{}) do
+  defp send_unauthorized_response(conn, _) do
     conn
     |> Plug.Conn.send_resp(401, "401 Unauthorized")
     |> Plug.Conn.halt

--- a/test/basic_auth_test.exs
+++ b/test/basic_auth_test.exs
@@ -26,13 +26,17 @@ defmodule BasicAuthTest do
 
   describe "custom function" do
     defmodule User do
-      def find_by_username_and_password(username, password) do
-        username == "robert" && password == "secret"
+      def find_by_username_and_password(conn, username, password) do
+        if username == "robert" && password == "secret" do
+          Plug.Conn.assign(conn, :current_user, %{name: "robert"})
+        else
+          Plug.Conn.halt(conn)
+        end
       end
     end
 
     defmodule SimpleDemoPlugWithModule do
-      use DemoPlugWithModule, &User.find_by_username_and_password/2
+      use DemoPlugWithModule, &User.find_by_username_and_password/3
     end
 
     test "no credentials provided" do

--- a/test/basic_auth_test.exs
+++ b/test/basic_auth_test.exs
@@ -13,6 +13,54 @@ defmodule BasicAuthTest do
     end
   end
 
+  defmodule DemoPlugWithModule do
+    defmacro __using__(function) do
+      quote bind_quoted: [function: function] do
+        use Plug.Builder
+        plug BasicAuth, callback: function
+        plug :index
+        defp index(conn, _opts), do: conn |> send_resp(200, "OK")
+      end
+    end
+  end
+
+  describe "custom function" do
+    defmodule User do
+      def find_by_username_and_password(username, password) do
+        username == "robert" && password == "secret"
+      end
+    end
+
+    defmodule SimpleDemoPlugWithModule do
+      use DemoPlugWithModule, &User.find_by_username_and_password/2
+    end
+
+    test "no credentials provided" do
+      conn = conn(:get, "/")
+      |> SimpleDemoPlugWithModule.call([])
+      assert conn.status == 401
+    end
+
+    test "wrong credentials provided" do
+      header_content = "Basic " <> Base.encode64("bad:credentials")
+
+      conn = conn(:get, "/")
+      |> put_req_header("authorization", header_content)
+      |> SimpleDemoPlugWithModule.call([])
+      assert conn.status == 401
+    end
+
+    test "right credentials provided" do
+      header_content = "Basic " <> Base.encode64("robert:secret")
+
+      conn = conn(:get, "/")
+      |> put_req_header("authorization", header_content)
+      |> SimpleDemoPlugWithModule.call([])
+      assert conn.status == 200
+    end
+    
+  end
+
   describe "credential checking" do
     defmodule SimpleDemoPlug do
       use DemoPlug, :my_auth


### PR DESCRIPTION
Inspired by rails:

```ruby
authenticate_or_request_with_http_basic do |username, password|
  #check in db:  User.find(username, password) 
end
```

This PR allows a custom function to be provided to the plug rather than only being able to check against hardcoded config values.

Use like:
```elixir
  plug BasicAuth, callback: &User.find_by_username_and_password/2
```