### PR TITLE
Show example for excluding specific actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ you want, such as finding the user from a database.
 
 Easy as that!
 
+### Authenticating only for specific actions
+
+If you're looking to authenticate only for a subset of actions in a controller you can use plug's `when action in` syntax as shown below
+
+  ```elixir
+    plug BasicAuth, [use_config: {: your_app, : your_key}] when action in [:edit, :delete]
+  ```
+
+  additionally you can exclude specific actions using `not`
+
+  ```elixir
+    plug BasicAuth, [use_config: {: your_app, : your_key}] when not action in [:index, :show]
+  ```
+
 ## Testing controllers with Basic Auth
 
 If you're storing credentials within configuration files, we can reuse them within our test files


### PR DESCRIPTION
This resolves #16 

In some cases its only required to authenticate a subset of actions which are defined in a controller and a developer might not want to create a different controller which doesn't require authentication.