### PR TITLE
Allow passwords to include a colon

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -6,6 +6,12 @@ config :basic_auth, my_auth: [
   realm: "Admin Area"
 ]
 
+config :basic_auth, my_auth_with_colons: [
+  username: "admin",
+  password: "simple_password:with:colons",
+  realm: "Admin Area"
+]
+
 config :basic_auth, my_auth_with_system: [
   username: {:system, "USERNAME"},
   password: {:system, "PASSWORD"},

--- a/lib/basic_auth.ex
+++ b/lib/basic_auth.ex
@@ -88,7 +88,7 @@ defmodule BasicAuth do
 
   defp respond(conn, ["Basic " <> encoded_string], options) do
     with {:ok, string} <- Base.decode64(encoded_string),
-         [username, password] <- String.split(string, ":")
+         [username, password] <- String.split(string, ":", parts: 2)
     do
       respond(conn, username, password, options)
     else


### PR DESCRIPTION
Basic authentication should allow for passwords to have colons. Split
the credentials into username and password only on the first colon as
the username is prohibited from including a colon in the RFC
https://tools.ietf.org/html/rfc2617#section-2.

closes #27