### PR TITLE
Add text/plain content type to 401 error response

### DIFF
--- a/lib/basic_auth/response.ex
+++ b/lib/basic_auth/response.ex
@@ -8,6 +8,7 @@ defmodule BasicAuth.Response do
   def unauthorise(conn, realm) do
     conn
     |> Plug.Conn.put_resp_header("www-authenticate", "Basic realm=\"#{realm || @default_realm}\"")
+    |> Plug.Conn.put_resp_content_type("text/plain")
     |> Plug.Conn.send_resp(401, "401 Unauthorized")
   end
 end


### PR DESCRIPTION
Likely solves an unreproducible problem of Safari downloading 401 response pages instead of displaying the error message response.