### PR TITLE
Pass in the connection for the example test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ end
 
 Then for any tests, I can simply pipe in this helper method to the connection process:
 ```elixir
-test "GET / successfully renders when basic auth credentials supplied" do
+test "GET / successfully renders when basic auth credentials supplied", %{conn: conn} do
   conn = conn
     |> using_basic_auth(@username, @password)
     |> get("/admin/users")
@@ -140,7 +140,7 @@ end
 
 And a test case without basic auth for completeness:
 ```elixir
-test "GET / without basic auth credentials prevents access" do
+test "GET / without basic auth credentials prevents access", %{conn: conn} do
   conn = conn
     |> get("/admin/users")
 


### PR DESCRIPTION
Otherwise variable `conn` does not exist and is being expanded to `conn()`, which is nowadays [deprecated](https://github.com/phoenixframework/phoenix/blob/83afabf/lib/phoenix/test/conn_test.ex#L118-L128):

> warning: using `conn/0` to build a connection is deprecated. Use `build_conn/0` instead.