### PR TITLE
mix: Set cowboy dependency to only :dev and :test

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule BasicAuth.Mixfile do
     [
      {:plug, "~> 0.14 or ~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev},
-     {:cowboy, "~> 1.0"},
+     {:cowboy, "~> 1.0", only: [:dev, :test]},
      {:credo, ">= 0.0.0", only: [:dev, :test]},
     ]
   end


### PR DESCRIPTION
Cowboy 1.x is needed to run tests, however the only runtime dependency of this project is Plug itself.

Removing Cowboy as dependency will allow this library to run with other HTTP servers, like Cowboy 2.x.

Fixes issue #38.