### PR TITLE
Bumping version 2.2.2 -> 2.2.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule BasicAuth.Mixfile do
       app: :basic_auth,
       description: "Basic Authentication Plug",
       package: package(),
-      version: "2.2.2",
+      version: "2.2.3",
       elixir: "~> 1.0",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Given that we are removing the need for cowboy in production we should probably bump the version.